### PR TITLE
Add custom actions into 1.16.x-plugins instance

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -21,6 +21,7 @@
     "@backstage/catalog-client": "1.4.3",
     "@backstage/catalog-model": "1.4.1",
     "@backstage/config": "1.0.8",
+    "@backstage/integration": "1.5.1",
     "@backstage/plugin-app-backend": "0.3.47",
     "@backstage/plugin-auth-backend": "0.18.5",
     "@backstage/plugin-auth-node": "0.2.16",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -41,6 +41,7 @@
     "@janus-idp/backstage-plugin-ocm-backend": "3.2.0",
     "@janus-idp/backstage-scaffolder-backend-module-kubernetes": "1.1.0",
     "@janus-idp/backstage-scaffolder-backend-module-quay": "1.1.0",
+    "@janus-idp/backstage-scaffolder-backend-module-sonarqube": "1.1.0",
     "@roadiehq/backstage-plugin-argo-cd-backend": "2.11.0",
     "@types/react": "^17",
     "@types/react-dom": "^17",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -38,6 +38,7 @@
     "@janus-idp/backstage-plugin-aap-backend": "1.1.2",
     "@janus-idp/backstage-plugin-keycloak-backend": "1.5.3",
     "@janus-idp/backstage-plugin-ocm-backend": "3.2.0",
+    "@janus-idp/backstage-scaffolder-backend-module-kubernetes": "1.1.0",
     "@roadiehq/backstage-plugin-argo-cd-backend": "2.11.0",
     "@types/react": "^17",
     "@types/react-dom": "^17",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -40,6 +40,7 @@
     "@janus-idp/backstage-plugin-keycloak-backend": "1.5.3",
     "@janus-idp/backstage-plugin-ocm-backend": "3.2.0",
     "@janus-idp/backstage-scaffolder-backend-module-kubernetes": "1.1.0",
+    "@janus-idp/backstage-scaffolder-backend-module-quay": "1.1.0",
     "@roadiehq/backstage-plugin-argo-cd-backend": "2.11.0",
     "@types/react": "^17",
     "@types/react-dom": "^17",

--- a/packages/backend/src/plugins/scaffolder.ts
+++ b/packages/backend/src/plugins/scaffolder.ts
@@ -8,6 +8,7 @@ import { Router } from 'express';
 import { ScmIntegrations } from '@backstage/integration';
 import type { PluginEnvironment } from '../types';
 import { createKubernetesNamespaceAction } from '@janus-idp/backstage-scaffolder-backend-module-kubernetes';
+import { createQuayRepositoryAction } from '@janus-idp/backstage-scaffolder-backend-module-quay';
 
 export default async function createPlugin(
   env: PluginEnvironment,
@@ -28,6 +29,7 @@ export default async function createPlugin(
   const actions = [
     ...builtInActions,
     createKubernetesNamespaceAction(catalogClient),
+    createQuayRepositoryAction(),
   ];
 
   return await createRouter({

--- a/packages/backend/src/plugins/scaffolder.ts
+++ b/packages/backend/src/plugins/scaffolder.ts
@@ -9,6 +9,7 @@ import { ScmIntegrations } from '@backstage/integration';
 import type { PluginEnvironment } from '../types';
 import { createKubernetesNamespaceAction } from '@janus-idp/backstage-scaffolder-backend-module-kubernetes';
 import { createQuayRepositoryAction } from '@janus-idp/backstage-scaffolder-backend-module-quay';
+import { createSonarQubeProjectAction } from '@janus-idp/backstage-scaffolder-backend-module-sonarqube';
 
 export default async function createPlugin(
   env: PluginEnvironment,
@@ -30,6 +31,7 @@ export default async function createPlugin(
     ...builtInActions,
     createKubernetesNamespaceAction(catalogClient),
     createQuayRepositoryAction(),
+    createSonarQubeProjectAction(),
   ];
 
   return await createRouter({

--- a/packages/backend/src/plugins/scaffolder.ts
+++ b/packages/backend/src/plugins/scaffolder.ts
@@ -1,7 +1,13 @@
 import { CatalogClient } from '@backstage/catalog-client';
-import { createRouter } from '@backstage/plugin-scaffolder-backend';
+import {
+  createRouter,
+  createBuiltinActions,
+} from '@backstage/plugin-scaffolder-backend';
 import { Router } from 'express';
+
+import { ScmIntegrations } from '@backstage/integration';
 import type { PluginEnvironment } from '../types';
+import { createKubernetesNamespaceAction } from '@janus-idp/backstage-scaffolder-backend-module-kubernetes';
 
 export default async function createPlugin(
   env: PluginEnvironment,
@@ -10,7 +16,22 @@ export default async function createPlugin(
     discoveryApi: env.discovery,
   });
 
+  const integrations = ScmIntegrations.fromConfig(env.config);
+
+  const builtInActions = createBuiltinActions({
+    integrations,
+    catalogClient,
+    config: env.config,
+    reader: env.reader,
+  });
+
+  const actions = [
+    ...builtInActions,
+    createKubernetesNamespaceAction(catalogClient),
+  ];
+
   return await createRouter({
+    actions,
     logger: env.logger,
     config: env.config,
     database: env.database,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5025,6 +5025,13 @@
     "@backstage/plugin-scaffolder-node" "^0.1.5"
     "@kubernetes/client-node" "^0.18.1"
 
+"@janus-idp/backstage-scaffolder-backend-module-quay@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@janus-idp/backstage-scaffolder-backend-module-quay/-/backstage-scaffolder-backend-module-quay-1.1.0.tgz#7516f81d7e9c22e661fdfb868165d889e9048b21"
+  integrity sha512-Kc0LbkcXz/JMQ2djYYrHSmSszb0ROhdVVr0KXuC/8dZxIwyXAflKfvzY4V4c22P0mlOcbjyNMCMqyWfaCjenhw==
+  dependencies:
+    "@backstage/plugin-scaffolder-node" "^0.1.5"
+
 "@janus-idp/shared-react@1.3.0":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@janus-idp/shared-react/-/shared-react-1.3.0.tgz#c945834ee77548ad0336f9f7b61b1e6d85cdcbe6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5032,6 +5032,14 @@
   dependencies:
     "@backstage/plugin-scaffolder-node" "^0.1.5"
 
+"@janus-idp/backstage-scaffolder-backend-module-sonarqube@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@janus-idp/backstage-scaffolder-backend-module-sonarqube/-/backstage-scaffolder-backend-module-sonarqube-1.1.0.tgz#4202346d3064f87bc19e39b60c4ae114b508bd18"
+  integrity sha512-8nGK8ycupiG3sR8BW0I2clskJZS8jprWk2HHgOa9HlfTCNI5wjCarKOgsE3nqnPFDry630y7LHC7Uj6pd86WPA==
+  dependencies:
+    "@backstage/plugin-scaffolder-node" "^0.1.5"
+    yaml "^2.2.1"
+
 "@janus-idp/shared-react@1.3.0":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@janus-idp/shared-react/-/shared-react-1.3.0.tgz#c945834ee77548ad0336f9f7b61b1e6d85cdcbe6"
@@ -21919,6 +21927,11 @@ yaml@^2.0.0, yaml@^2.2.2:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.3.1.tgz#02fe0975d23cd441242aa7204e09fc28ac2ac33b"
   integrity sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==
+
+yaml@^2.2.1:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.3.2.tgz#f522db4313c671a0ca963a75670f1c12ea909144"
+  integrity sha512-N/lyzTPaJasoDmfV7YTrYCI0G/3ivm/9wdG0aHuheKowWQwGTsK0Eoiw6utmzAnI6pkJa0DUVygvp3spqqEKXg==
 
 yargs-parser@^21.1.1:
   version "21.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5015,6 +5015,16 @@
     lodash "^4.17.19"
     react-use "^17.2.4"
 
+"@janus-idp/backstage-scaffolder-backend-module-kubernetes@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@janus-idp/backstage-scaffolder-backend-module-kubernetes/-/backstage-scaffolder-backend-module-kubernetes-1.1.0.tgz#a112944ca1a0898890b66f15cf807bd0203aace9"
+  integrity sha512-tSiEwIgN42eG7Y3lxK2ZvzuZIhzN5k5iCgH6KTEFLcVlYrU4b4RBQi3Wr72Ylspm6Rao2dT2I/HtiYGju4LntQ==
+  dependencies:
+    "@backstage/catalog-client" "^1.4.3"
+    "@backstage/catalog-model" "^1.4.1"
+    "@backstage/plugin-scaffolder-node" "^0.1.5"
+    "@kubernetes/client-node" "^0.18.1"
+
 "@janus-idp/shared-react@1.3.0":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@janus-idp/shared-react/-/shared-react-1.3.0.tgz#c945834ee77548ad0336f9f7b61b1e6d85cdcbe6"
@@ -8147,12 +8157,19 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.4.tgz#cd667bcfdd025213aafb7ca5915a932590acdcdc"
   integrity sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==
 
-"@types/react-dom@<18.0.0", "@types/react-dom@^17", "@types/react-dom@^18.0.0":
+"@types/react-dom@<18.0.0", "@types/react-dom@^17":
   version "17.0.20"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.20.tgz#e0c8901469d732b36d8473b40b679ad899da1b53"
   integrity sha512-4pzIjSxDueZZ90F52mU3aPoogkHIoSIDG+oQ+wQK7Cy2B9S+MvOqY0uEA/qawKz381qrEDkvpwyt8Bm31I8sbA==
   dependencies:
     "@types/react" "^17"
+
+"@types/react-dom@^18.0.0":
+  version "18.2.7"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.2.7.tgz#67222a08c0a6ae0a0da33c3532348277c70abb63"
+  integrity sha512-GRaAEriuT4zp9N4p1i8BDBYmEyfo+xQ3yHjJU4eiK5NDa1RmUZG+unZABUTK4/Ox/M+GaHwb6Ow8rUITrtjszA==
+  dependencies:
+    "@types/react" "*"
 
 "@types/react-is@^18.2.1":
   version "18.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2740,7 +2740,7 @@
     "@material-ui/lab" "4.0.0-alpha.61"
     react-use "^17.2.4"
 
-"@backstage/integration@^1.5.1":
+"@backstage/integration@1.5.1", "@backstage/integration@^1.5.1":
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/@backstage/integration/-/integration-1.5.1.tgz#10a64060ba74251cc6256ab8dcb3394d4beb8201"
   integrity sha512-b3G8AwlNyieDVp+rmIsKc07phKtum4DUdttWbxPFqhBEiA8qZkMZ4X31oEaR+mp+DkM+RjFt0LD89QIQeuKLUg==


### PR DESCRIPTION
### Description
Adds the following custom actions:

- [Kubernetes Actions](https://github.com/janus-idp/backstage-plugins/tree/bundle-2.0/plugins/kubernetes-actions) v1.1.0
- [Quay Actions](https://github.com/janus-idp/backstage-plugins/tree/bundle-2.0/plugins/quay-actions) v1.1.0
- [Sonarqube Actions](https://github.com/janus-idp/backstage-plugins/tree/main/plugins/sonarqube-actions) v1.1.0

Also installed the @backstage/integrations package v1.5.1
### What issue(s) does this fix?
Fixes #8 