### PR TITLE
Downgrade ArgoCD plugins in 1.15.x-plugins to match RHPIB 2.0 versions

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -53,7 +53,7 @@
     "@janus-idp/backstage-plugin-topology": "1.15.1",
     "@material-ui/core": "4.12.2",
     "@material-ui/icons": "4.9.1",
-    "@roadiehq/backstage-plugin-argo-cd": "2.2.20",
+    "@roadiehq/backstage-plugin-argo-cd": "2.2.17",
     "add": "2.0.6",
     "app": "0.1.0",
     "history": "5.0.0",

--- a/packages/app/src/components/catalog/EntityPage/Content/CI-CD.tsx
+++ b/packages/app/src/components/catalog/EntityPage/Content/CI-CD.tsx
@@ -7,6 +7,10 @@ import {
   isTektonCIAvailable,
   LatestPipelineRun,
 } from '@janus-idp/backstage-plugin-tekton';
+import {
+  EntityArgoCDHistoryCard,
+  isArgocdAvailable,
+} from '@roadiehq/backstage-plugin-argo-cd';
 import Grid from '@mui/material/Grid';
 import React from 'react';
 
@@ -23,6 +27,13 @@ export const cicdContent = (
       <EntitySwitch.Case if={isTektonCIAvailable}>
         <Grid item xs={12}>
           <LatestPipelineRun linkTekton />
+        </Grid>
+      </EntitySwitch.Case>
+    </EntitySwitch>
+    <EntitySwitch>
+      <EntitySwitch.Case if={isArgocdAvailable}>
+        <Grid item xs={12}>
+          <EntityArgoCDHistoryCard />
         </Grid>
       </EntitySwitch.Case>
     </EntitySwitch>

--- a/packages/app/src/components/catalog/EntityPage/Content/Overview.tsx
+++ b/packages/app/src/components/catalog/EntityPage/Content/Overview.tsx
@@ -8,7 +8,7 @@ import { EntityCatalogGraphCard } from '@backstage/plugin-catalog-graph';
 import React from 'react';
 import Grid from '@mui/material/Grid';
 import {
-  EntityArgoCDHistoryCard,
+  EntityArgoCDOverviewCard,
   isArgocdAvailable,
 } from '@roadiehq/backstage-plugin-argo-cd';
 import { entityWarningContent } from './EntityWarning';
@@ -32,7 +32,7 @@ export const overviewContent = (
     <EntitySwitch>
       <EntitySwitch.Case if={isArgocdAvailable}>
         <Grid item sm={6}>
-          <EntityArgoCDHistoryCard />
+          <EntityArgoCDOverviewCard />
         </Grid>
       </EntitySwitch.Case>
     </EntitySwitch>

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -42,7 +42,7 @@
     "@janus-idp/backstage-scaffolder-backend-module-kubernetes": "1.1.0",
     "@janus-idp/backstage-scaffolder-backend-module-quay": "1.1.0",
     "@janus-idp/backstage-scaffolder-backend-module-sonarqube": "1.1.0",
-    "@roadiehq/backstage-plugin-argo-cd-backend": "2.11.0",
+    "@roadiehq/backstage-plugin-argo-cd-backend": "2.8.1",
     "add": "^2.0.6",
     "app": "link:../app",
     "backend": "^0.0.0",

--- a/packages/backend/src/plugins/catalog.ts
+++ b/packages/backend/src/plugins/catalog.ts
@@ -50,7 +50,8 @@ export default async function createPlugin(
   const isAnsibleEnabled =
     env.config.getOptionalBoolean('enabled.ansible') || false;
   const isOcmEnabled = env.config.getOptionalBoolean('enabled.ocm') || false;
-  const is3ScaleEnabled = env.config.getOptionalBoolean('enabled.threescale') || false;   
+  const is3ScaleEnabled =
+    env.config.getOptionalBoolean('enabled.threescale') || false;
 
   if (isAnsibleEnabled) {
     builder.addEntityProvider(

--- a/yarn.lock
+++ b/yarn.lock
@@ -7441,13 +7441,13 @@
     lodash "^4.17.21"
     lodash-es "^4.17.21"
 
-"@roadiehq/backstage-plugin-argo-cd-backend@2.11.0":
-  version "2.11.0"
-  resolved "https://registry.yarnpkg.com/@roadiehq/backstage-plugin-argo-cd-backend/-/backstage-plugin-argo-cd-backend-2.11.0.tgz#1adeacf582ada17b079c007562e988825bfd06d1"
-  integrity sha512-N1DtAPaAau0gYwDHXm25xxoYX/oD5t0A0138tqcR1bIc6OXFycrJ8GsLimYNHrliqZeyUFdjUAMVvTuDrucfQw==
+"@roadiehq/backstage-plugin-argo-cd-backend@2.8.1":
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/@roadiehq/backstage-plugin-argo-cd-backend/-/backstage-plugin-argo-cd-backend-2.8.1.tgz#711be977804a5bdfb780065d5adfaa82104d7d69"
+  integrity sha512-fphNaxKICL1EXshHlHv1SbUKguVj34iKs59hFEmgMRyYwLYkcnhYlSDvZ/9X2C7R/lsmnMx1eSOjRkCxgvdZYA==
   dependencies:
-    "@backstage/backend-common" "^0.19.1"
-    "@backstage/catalog-client" "^1.4.3"
+    "@backstage/backend-common" "^0.19.0"
+    "@backstage/catalog-client" "^1.4.2"
     "@backstage/config" "^1.0.8"
     "@types/express" "^4.17.6"
     cross-fetch "^3.1.4"
@@ -7456,16 +7456,16 @@
     winston "^3.2.1"
     yn "^4.0.0"
 
-"@roadiehq/backstage-plugin-argo-cd@2.2.20":
-  version "2.2.20"
-  resolved "https://registry.yarnpkg.com/@roadiehq/backstage-plugin-argo-cd/-/backstage-plugin-argo-cd-2.2.20.tgz#194e58d786307ede132eef62151832f061954f2d"
-  integrity sha512-3hALyJLvSTNBQqIsQP6t4UThvOb/eYX24zUCVQ4kPyyC/md9IOQqDPZAmZep4W4yP5VKrnLkbHgVsMglHsoSoQ==
+"@roadiehq/backstage-plugin-argo-cd@2.2.17":
+  version "2.2.17"
+  resolved "https://registry.yarnpkg.com/@roadiehq/backstage-plugin-argo-cd/-/backstage-plugin-argo-cd-2.2.17.tgz#64afb4528c734ba69b7007101e9ab9c6cf02a24f"
+  integrity sha512-3gxvPioaut921GxTCdnrNjZY2NyCNK5Wa6H09M4UuoksF7MxAHKsKsOETK9Fc7s56Mu4sRjY1RGZ1GYEWgEbVw==
   dependencies:
-    "@backstage/catalog-model" "^1.4.1"
-    "@backstage/core-components" "^0.13.3"
-    "@backstage/core-plugin-api" "^1.5.3"
-    "@backstage/plugin-catalog-react" "^1.8.0"
-    "@backstage/theme" "^0.4.1"
+    "@backstage/catalog-model" "^1.4.0"
+    "@backstage/core-components" "^0.13.2"
+    "@backstage/core-plugin-api" "^1.5.2"
+    "@backstage/plugin-catalog-react" "^1.7.0"
+    "@backstage/theme" "^0.4.0"
     "@material-ui/core" "^4.11.0"
     "@material-ui/icons" "^4.9.1"
     "@material-ui/lab" "4.0.0-alpha.45"
@@ -9131,7 +9131,7 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.4.tgz#cd667bcfdd025213aafb7ca5915a932590acdcdc"
   integrity sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==
 
-"@types/react-dom@*", "@types/react-dom@17", "@types/react-dom@<18.0.0":
+"@types/react-dom@*", "@types/react-dom@<18.0.0":
   version "17.0.20"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.20.tgz#e0c8901469d732b36d8473b40b679ad899da1b53"
   integrity sha512-4pzIjSxDueZZ90F52mU3aPoogkHIoSIDG+oQ+wQK7Cy2B9S+MvOqY0uEA/qawKz381qrEDkvpwyt8Bm31I8sbA==
@@ -9183,7 +9183,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@17", "@types/react@^16.13.1 || ^17.0.0", "@types/react@^17":
+"@types/react@*", "@types/react@^16.13.1 || ^17.0.0", "@types/react@^17":
   version "17.0.65"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.65.tgz#95f6a2ab61145ffb69129d07982d047f9e0870cd"
   integrity sha512-oxur785xZYHvnI7TRS61dXbkIhDPnGfsXKv0cNXR/0ml4SipRIFpSMzA7HMEfOywFwJ5AOnPrXYTEiTRUQeGlQ==
@@ -9961,7 +9961,7 @@ app@0.1.0:
     "@janus-idp/backstage-plugin-topology" "1.15.1"
     "@material-ui/core" "4.12.2"
     "@material-ui/icons" "4.9.1"
-    "@roadiehq/backstage-plugin-argo-cd" "2.2.20"
+    "@roadiehq/backstage-plugin-argo-cd" "2.2.17"
     add "2.0.6"
     app "0.1.0"
     history "5.0.0"


### PR DESCRIPTION
### Description

- Downgrade argocd frontend to 2.2.17 (from 2.2.20) and argocd backend to 2.8.1 (from 2.11.0) to match RHPIB 2.0 versions
- Update the Overview card to use the `EntityArgoCDOverviewCard` instead of the `EntityArgoCDHistoryCard`
- Add the `EntityArgoCDHistoryCard` into the CI/CD tab 